### PR TITLE
5 Plots on main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
 	<script src="views/view-ctl/power-ctlr.js"></script>
 	<script src="views/view-ctl/config.ctlr.js"></script>
 	<script src="views/view-ctl/filter-ctlr.js"></script>
+	<script src="views/view-ctl/main.ctlr.js"></script>
 	<script src="views/view-ctl/crd.ctlr.js"></script>
 	<script src="views/view-ctl/pas-ctlr.js"></script>
 	<script src="views/view-ctl/pas-spk-ctlr.js"></script>

--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@
 	<navi></navi>
 	<div class="container">
 		<div class="row">
-			<div class="col-xl-11 col-lg-10 col-md-9 col-sm-9" role="main">
+			<div class="col-xl-11 col-lg-10 col-md-10 col-sm-10" role="main">
 				<ng-view></ng-view>
 			</div>
-			<div class="col-xl-1 col-lg-2 col-md-3 col-sm-3" role="complementary">
+			<div class="col-xl-1 col-lg-2 col-md-2 col-sm-2" role="complementary">
 				<sidebar></sidebar>
 			</div>
 		</div>

--- a/views/main.html
+++ b/views/main.html
@@ -13,6 +13,6 @@
 	</ul>
 </p>
 <div ng-controller="main2">
-  <nvd3 options="optionsPlot1" data="plot1Data" config="{refreshDataOnly:true}"></nvd3>
-  <nvd3 options="optionsPlot2" data="plot2Data" config="{refreshDataOnly:true}"></nvd3>
+  <nvd3 options="plot1Options" data="plot1Data" config="{refreshDataOnly:true}"></nvd3>
+  <nvd3 options="plot2Options" data="plot2Data" config="{refreshDataOnly:true}"></nvd3>
 </div>

--- a/views/main.html
+++ b/views/main.html
@@ -1,3 +1,24 @@
+<div ng-controller="main2">
+  <div class="row" >
+      <nvd3 options="plot1Options" data="plot1Data" config="{refreshDataOnly:true}"></nvd3>
+  </div>
+  <div class="row" >
+    <div class="col-sm-6" >
+      <nvd3 options="plot2Options" data="plot2Data" config="{refreshDataOnly:true}"></nvd3>
+    </div>
+    <div class="col-sm-6" >
+      <nvd3 options="plot3Options" data="plot3Data" config="{refreshDataOnly:true}"></nvd3>
+    </div>
+  </div>
+  <div class="row" >
+    <div class="col-sm-6" >
+      <nvd3 options="plot4Options" data="plot4Data" config="{refreshDataOnly:true}"></nvd3>
+    </div>
+    <div class="col-sm-6" >
+      <nvd3 options="plot5Options" data="plot5Data" config="{refreshDataOnly:true}"></nvd3>
+    </div>
+  </div>
+</div>
 <p>
 	This is the Main page.  Likely will have:
 
@@ -12,7 +33,3 @@
 		<li></li>
 	</ul>
 </p>
-<div ng-controller="main2">
-  <nvd3 options="plot1Options" data="plot1Data" config="{refreshDataOnly:true}"></nvd3>
-  <nvd3 options="plot2Options" data="plot2Data" config="{refreshDataOnly:true}"></nvd3>
-</div>

--- a/views/main.html
+++ b/views/main.html
@@ -12,3 +12,7 @@
 		<li></li>
 	</ul>
 </p>
+<div ng-controller="main2">
+  <nvd3 options="optionsPlot1" data="plot1Data" config="{refreshDataOnly:true}"></nvd3>
+  <nvd3 options="optionsPlot2" data="plot2Data" config="{refreshDataOnly:true}"></nvd3>
+</div>

--- a/views/view-ctl/main.ctlr.js
+++ b/views/view-ctl/main.ctlr.js
@@ -4,9 +4,6 @@
         controller('main2',
                    ['$scope', 'Data',
                     function ($scope, Data) {
-                        
-                        $scope.rd = {};
-                        
                         $scope.purge = false;
                         
                         $scope.data = Data;
@@ -15,148 +12,15 @@
                             console.log(points, evt);
                         };
 
-                        $scope.optionsPlot1 = {
-                            chart: {
-                                type: 'lineChart',
-                                height: 300,
-                                margin: {
-                                    top: 20,
-                                    right: 40,
-                                    bottom: 60,
-                                    left: 75
-                                },
-                                x: function (d) {
-                                    return d.x;
-                                },
-                                y: function (d) {
-                                    return d.y;
-                                },
-                                useInteractiveGuideline: false,
-                                yAxis: {
-                                    tickFormat: function (d) {
-                                        return d3.format('0.01f')(d);
-                                    },
-                                    axisLabel: 'Testing'
-                                },
-                                xAxis: {
-                                    tickFormat: function (d) {
-                                        return d3.time.format('%X')(new Date(d));
-                                    },
-                                    rotateLabels: -45
-                                },
-                                transitionDuration: 0,
-                                showXAxis: true,
-                                showYAxis: true
-                            }
-                        };
+                        $scope.plot1Options = getPlotOptions('plot 1', 0, false);
+                        $scope.plot2Options = getPlotOptions('plot 2', 0, true);
 
-                        /** Options used for plotting. */
-                        $scope.optionsPlot2 = {
-                            chart: {
-                                type: 'lineChart',
-                                height: 300,
-                                margin: {
-                                    top: 20,
-                                    right: 10,
-                                    bottom: 60,
-                                    left: 75
-                                },
-                                x: function(d) {
-                                    return d.x;
-                                },
-                                y: function(d) {
-                                    return d.y;
-                                },
-                                useInteractiveGuideline: true,
-                                yAxis: {
-                                    tickFormat: function(d) {
-                                        return d3.format('0.01f')(d);
-                                    },
-                                    axisLabel: 'Testing'
-                                },
-                                xAxis: {
-                                    tickFormat: function(d) {
-                                        return d3.time.format('%X')(new Date(d));
-                                    },
-                                    rotateLabels: -45
-                                },
-                                transitionDuration: 500,
-                                showXAxis: true,
-                                showYAxis: true
-                            }
-                        };
-
-                        $scope.plot1Data = [{
-                            values: [],
-                            key: 'Cell 0'
-                        }, {
-                            values: [],
-                            key: 'Cell 1'
-                        }, {
-                            values: [],
-                            key: 'Cell 2'
-                        }, {
-                            values: [],
-                            key: 'Cell 3'
-                        }, {
-                            values: [],
-                            key: 'Cell 4'
-                        }];
-                        $scope.plot2Data = [{
-                            values: [],
-                            key: 'Cell 0'
-                        }, {
-                            values: [],
-                            key: 'Cell 1'
-                        }, {
-                            values: [],
-                            key: 'Cell 2'
-                        }, {
-                            values: [],
-                            key: 'Cell 3'
-                        }, {
-                            values: [],
-                            key: 'Cell 4'
-                        }];
+                        $scope.plot1Data = getEmptyData();
+                        $scope.plot2Data = getEmptyData();
 
                         $scope.$on('dataAvailable', function () {
 
                             $scope.data = Data;
-
-                            var dataOut = {
-                                "plot1Data": [{
-                                    values: [],
-                                    key: 'Cell 0'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 1'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 2'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 3'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 4'
-                                }],
-                                "plot2Data": [{
-                                    values: [],
-                                    key: 'Cell 0'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 1'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 2'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 3'
-                                }, {
-                                    values: [],
-                                    key: 'Cell 4'
-                                }]
-                            };
                             
                             for (k = 0; k < Data.crd.cell.length; k++) {
                                 $scope.plot1Data[k].values = Data.crd.cell[k].avg_rd;
@@ -169,4 +33,67 @@
                     }
                    ]);
 
+    function getEmptyData() {
+        return [{
+            values: [],
+            key: 'Cell 0'
+        }, {
+            values: [],
+            key: 'Cell 1'
+        }, {
+            values: [],
+            key: 'Cell 2'
+        }, {
+            values: [],
+            key: 'Cell 3'
+        }, {
+            values: [],
+            key: 'Cell 4'
+        }]; 
+    }
+    
+    function getPlotOptions(yAxisLabel, transitionDuration, isTimePlot) { 
+        var xTickFunction;
+        if (isTimePlot) {
+            xTickFunction = function (d) {
+                return d3.time.format('%X')(new Date(d));
+            };
+        } else {
+            xTickFunction = function (d) {
+                return d;
+            };
+        }
+        return {
+            chart: {
+                type: 'lineChart',
+                height: 300,
+                margin: {
+                    top: 20,
+                    right: 10,
+                    bottom: 60,
+                    left: 75
+                },
+                x: function (d) {
+                    return d.x;
+                },
+                y: function (d) {
+                    return d.y;
+                },
+                useInteractiveGuideline: false,
+                yAxis: {
+                    tickFormat: function (d) {
+                        return d3.format('0.01f')(d);
+                    },
+                    axisLabel: yAxisLabel
+                },
+                xAxis: {
+                    tickFormat: xTickFunction,
+                    rotateLabels: -45
+                },
+                transitionDuration: transitionDuration,
+                showXAxis: true,
+                showYAxis: true
+            }
+        };
+    }
 })();

--- a/views/view-ctl/main.ctlr.js
+++ b/views/view-ctl/main.ctlr.js
@@ -12,22 +12,30 @@
                             console.log(points, evt);
                         };
 
-                        $scope.plot1Options = getPlotOptions('plot 1', 0, false);
-                        $scope.plot2Options = getPlotOptions('plot 2', 0, true);
+                        $scope.plot1Options = getPlotOptions('plot 1', 0, true);
+                        $scope.plot2Options = getPlotOptions('plot 2', 0, false);
+                        $scope.plot3Options = getPlotOptions('plot 3', 0, false);
+                        $scope.plot4Options = getPlotOptions('plot 4', 0, true);
+                        $scope.plot5Options = getPlotOptions('plot 5', 0, true);
 
                         $scope.plot1Data = getEmptyData();
                         $scope.plot2Data = getEmptyData();
+                        $scope.plot3Data = getEmptyData();
+                        $scope.plot4Data = getEmptyData();
+                        $scope.plot5Data = getEmptyData();
 
                         $scope.$on('dataAvailable', function () {
 
                             $scope.data = Data;
                             
-                            for (k = 0; k < Data.crd.cell.length; k++) {
-                                $scope.plot1Data[k].values = Data.crd.cell[k].avg_rd;
-                            }
-
                             for (i = 1; i < 5; i++) {
-                                $scope.plot2Data[i].values = Data.pas.cell[i].IA;
+                                $scope.plot1Data[i].values = Data.pas.cell[i].f0;
+                                $scope.plot4Data[i].values = Data.pas.cell[i].IA;
+                                $scope.plot5Data[i].values = Data.pas.cell[i].Q;
+                            }
+                            for (k = 0; k < Data.crd.cell.length; k++) {
+                                $scope.plot2Data[k].values = Data.crd.cell[k].avg_rd;
+                                $scope.plot3Data[k].values = Data.crd.cell[k].fit_rd;
                             }
                         });
                     }

--- a/views/view-ctl/main.ctlr.js
+++ b/views/view-ctl/main.ctlr.js
@@ -1,0 +1,172 @@
+(function () {
+    angular.
+        module('main').
+        controller('main2',
+                   ['$scope', 'Data',
+                    function ($scope, Data) {
+                        
+                        $scope.rd = {};
+                        
+                        $scope.purge = false;
+                        
+                        $scope.data = Data;
+                        
+                        $scope.onClick = function (points, evt) {
+                            console.log(points, evt);
+                        };
+
+                        $scope.optionsPlot1 = {
+                            chart: {
+                                type: 'lineChart',
+                                height: 300,
+                                margin: {
+                                    top: 20,
+                                    right: 40,
+                                    bottom: 60,
+                                    left: 75
+                                },
+                                x: function (d) {
+                                    return d.x;
+                                },
+                                y: function (d) {
+                                    return d.y;
+                                },
+                                useInteractiveGuideline: false,
+                                yAxis: {
+                                    tickFormat: function (d) {
+                                        return d3.format('0.01f')(d);
+                                    },
+                                    axisLabel: 'Testing'
+                                },
+                                xAxis: {
+                                    tickFormat: function (d) {
+                                        return d3.time.format('%X')(new Date(d));
+                                    },
+                                    rotateLabels: -45
+                                },
+                                transitionDuration: 0,
+                                showXAxis: true,
+                                showYAxis: true
+                            }
+                        };
+
+                        /** Options used for plotting. */
+                        $scope.optionsPlot2 = {
+                            chart: {
+                                type: 'lineChart',
+                                height: 300,
+                                margin: {
+                                    top: 20,
+                                    right: 10,
+                                    bottom: 60,
+                                    left: 75
+                                },
+                                x: function(d) {
+                                    return d.x;
+                                },
+                                y: function(d) {
+                                    return d.y;
+                                },
+                                useInteractiveGuideline: true,
+                                yAxis: {
+                                    tickFormat: function(d) {
+                                        return d3.format('0.01f')(d);
+                                    },
+                                    axisLabel: 'Testing'
+                                },
+                                xAxis: {
+                                    tickFormat: function(d) {
+                                        return d3.time.format('%X')(new Date(d));
+                                    },
+                                    rotateLabels: -45
+                                },
+                                transitionDuration: 500,
+                                showXAxis: true,
+                                showYAxis: true
+                            }
+                        };
+
+                        $scope.plot1Data = [{
+                            values: [],
+                            key: 'Cell 0'
+                        }, {
+                            values: [],
+                            key: 'Cell 1'
+                        }, {
+                            values: [],
+                            key: 'Cell 2'
+                        }, {
+                            values: [],
+                            key: 'Cell 3'
+                        }, {
+                            values: [],
+                            key: 'Cell 4'
+                        }];
+                        $scope.plot2Data = [{
+                            values: [],
+                            key: 'Cell 0'
+                        }, {
+                            values: [],
+                            key: 'Cell 1'
+                        }, {
+                            values: [],
+                            key: 'Cell 2'
+                        }, {
+                            values: [],
+                            key: 'Cell 3'
+                        }, {
+                            values: [],
+                            key: 'Cell 4'
+                        }];
+
+                        $scope.$on('dataAvailable', function () {
+
+                            $scope.data = Data;
+
+                            var dataOut = {
+                                "plot1Data": [{
+                                    values: [],
+                                    key: 'Cell 0'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 1'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 2'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 3'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 4'
+                                }],
+                                "plot2Data": [{
+                                    values: [],
+                                    key: 'Cell 0'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 1'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 2'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 3'
+                                }, {
+                                    values: [],
+                                    key: 'Cell 4'
+                                }]
+                            };
+                            
+                            for (k = 0; k < Data.crd.cell.length; k++) {
+                                $scope.plot1Data[k].values = Data.crd.cell[k].avg_rd;
+                            }
+
+                            for (i = 1; i < 5; i++) {
+                                $scope.plot2Data[i].values = Data.pas.cell[i].IA;
+                            }
+                        });
+                    }
+                   ]);
+
+})();


### PR DESCRIPTION
Now have 5 plots on main page. I'll send an email about the specific data in each plot. I thought that it would be good to have one wide plot at the very top for the most important info. Then rows containing two plots each below that. We could easily add more rows with two plots.

I made a slight change to the column widths in index.html: It looked better to my eye to set the sidebar to a maximum of 2 columns for the smaller screens. Change it back if you prefer the old way (3 cols on smaller screens).

Let me know whether this is on the right track.
